### PR TITLE
Allow dashboard to be manually set

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -110,7 +110,7 @@ get '/views/:widget?.html' do
 end
 
 get '/*' do
-  dashboard = File.join(params[:splat])
+  dashboard = @dashboard || File.join(params[:splat])
   protected!
   tilt_html_engines.each do |suffix, _|
     file = File.join(settings.views, "#{dashboard}.#{suffix}")


### PR DESCRIPTION
This just adds an optional instance variable which can be set in a before filter, so the dashboard location doesn't have to match the url structure, so we can have more dynamic dashboards
