### PR TITLE
Get the view path of a widget on IE

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -34,7 +34,7 @@ Dashing.params = Batman.URI.paramsFromQuery(window.location.search.slice(1));
 class Dashing.Widget extends Batman.View
   constructor:  ->
     # Set the view path
-    @constructor::source = Batman.Filters.underscore(@constructor.name)
+    @constructor::source = Batman.Filters.underscore(@getName())
     super
 
     @mixin($(@node).data())
@@ -54,7 +54,15 @@ class Dashing.Widget extends Batman.View
 
   @::on 'ready', ->
     Dashing.Widget.fire 'ready'
-
+    
+  getName: () =>
+    if (@constructor.name?)
+      return @constructor.name
+    # get constructor name from Function.toString
+    funcNameRegex = /function ([^\(]{1,})\(/;
+    results = (funcNameRegex).exec(@constructor.toString())
+    if (results && results.length > 1) then results[1].trim() else ""
+    
   receiveData: (data) =>
     @mixin(data)
     @onData(data)


### PR DESCRIPTION
Replace constructor.name with a new function called getName that works on Internet Explorer.
This new function is based on this workaround to support Function.name: http://matt.scharley.me/2012/03/09/monkey-patch-name-ie.html

Combined with PR #310, the library works fine on IE.

Disclaimer: I do not use Internet Explorer! However, I developed a TV panel using your library, and now we have to support IE...
